### PR TITLE
Merging OSCAR/PISCO with bergen (inference-only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ tests/index/
 tests/exp/
 tests/run/
 outputs/
+results/
 wandb/

--- a/config/dataset/kilt_multi_qa_ms_marco.yaml
+++ b/config/dataset/kilt_multi_qa_ms_marco.yaml
@@ -1,0 +1,22 @@
+train:
+    doc: 
+        init_args:
+            _target_: modules.dataset_processor.MergedDocDataset
+            in_dataset_names: ["ms-marco", "kilt-100w"]
+            in_dataset_splits: ["full", "full"]
+            out_dataset_name: "multi_qa_ms_marco"
+            split: "train"
+    query: 
+        init_args:
+            _target_: modules.dataset_processor.KiltMultiQAMSMarco
+            split: "train"
+dev:
+    doc: 
+        null
+    query: 
+        null
+test:
+    doc: 
+        null
+    query: 
+        null 

--- a/config/generator/cocom.yaml
+++ b/config/generator/cocom.yaml
@@ -1,0 +1,13 @@
+init_args: 
+    _target_: models.generators.llm_cocom.LLMCocom
+    model_name: null
+    checkpoint_path: null
+    batch_size: 64
+    decoder_model_name: 'mistralai/Mistral-7B-Instruct-v0.2'
+    context_max_length: 128
+    max_new_tokens: 128
+    model_max_length: 1280
+    compr_rate: null
+    compr_model_name: null
+    compr_n_layers: null
+    quantization: 'no'

--- a/config/generator/cocom.yaml
+++ b/config/generator/cocom.yaml
@@ -1,7 +1,6 @@
 init_args: 
     _target_: models.generators.llm_cocom.LLMCocom
     model_name: null
-    checkpoint_path: null
     batch_size: 64
     decoder_model_name: 'mistralai/Mistral-7B-Instruct-v0.2'
     context_max_length: 128

--- a/config/generator/mistral-small.yaml
+++ b/config/generator/mistral-small.yaml
@@ -1,0 +1,6 @@
+init_args: 
+  _target_: models.generators.vllm.LLM
+  model_name: "mistralai/Mistral-Small-24B-Instruct-2501"
+  max_new_tokens: 128
+  max_length: 32000
+  batch_size: 64

--- a/config/generator/qwen-2-7b-vllm.yaml
+++ b/config/generator/qwen-2-7b-vllm.yaml
@@ -1,0 +1,6 @@
+init_args: 
+  _target_: models.generators.vllm.LLM
+  model_name: Qwen/Qwen2-7B-Instruct
+  max_new_tokens: 128
+  max_length: 16384
+  batch_size: 32

--- a/config/train/cocom.yaml
+++ b/config/train/cocom.yaml
@@ -1,0 +1,15 @@
+test_size_ratio: 256
+n_train_samples: null
+trainer:
+  dataloader_num_workers: 4
+  eval_accumulation_steps: 16
+  num_train_epochs: 1
+  weight_decay: 0.1
+  warmup_ratio: 0.05
+  learning_rate: 1e-4
+  gradient_accumulation_steps: 32
+  per_device_train_batch_size: 4
+  per_device_eval_batch_size: 4
+  bf16: True
+  report_to: "tensorboard"
+  max_grad_norm: 1.

--- a/models/generators/llm.py
+++ b/models/generators/llm.py
@@ -233,12 +233,12 @@ class LLM(Generator):
                 # Count the number of padding tokens on the left
                 left_padding_count = (attention_mask_tensor[i] == 0).sum().item()
                 
-                if examples[i]['label_start_index']+left_padding_count + 1 > label_ids.size(1):
+                if examples[i]['label_start_index'] + left_padding_count + 1 > label_ids.size(1):
                     warnings.warn("Docs + query is too long: label will be ignored. If it happens too often consider\
                         increasing the `max_seq_length`.")
                     
                 # We now identify the position of the starting index of the label in the tokenized seq
-                # It is to delimiate where the loss should be computed.
+                # It is to delimitate where the loss should be computed.
                 no_loss_start_index = self.get_no_loss_start_index(ids=label_ids[i], 
                                                                    original_labels=label[i],
                                                                    label_start_index=examples[i]['label_start_index'],

--- a/models/generators/llm_cocom.py
+++ b/models/generators/llm_cocom.py
@@ -110,7 +110,7 @@ class LLMCocom(Generator):
                 queries += data_dict['query']
                 ranking_labels += data_dict['ranking_label']
                 instructions += instruction
-                generated_response = self.generate(data_dict['model_input'], return_doc_embeddings=False)
+                generated_response = self.generate(data_dict['model_input'])
                 responses += generated_response
         
         return query_ids, queries, instructions, responses, labels, ranking_labels

--- a/models/generators/llm_cocom.py
+++ b/models/generators/llm_cocom.py
@@ -24,7 +24,6 @@ class LLMCocom(Generator):
                  ):
         """
         Class to use cocom with compression
-        checkpoint_path: path to a COCOM checkpoint
         max_new_tokens: maximum number of tokens for generation
         model_max_length: maximum length used in the final query (should be large enough)
         """

--- a/models/generators/llm_cocom.py
+++ b/models/generators/llm_cocom.py
@@ -1,0 +1,260 @@
+import torch
+import random
+import warnings
+
+from tqdm import tqdm
+from torch.utils.data import DataLoader
+
+from models.generators.generator import Generator
+
+
+class LLMCocom(Generator):
+    def __init__(self,
+                 model_name: str, # in practice this is checkpoint path
+                 batch_size: int,
+                 max_new_tokens: int = 128, # TODO ?
+                 max_doc_len: int = 100,
+                 max_length: int = None,
+                 context_max_length: int = 128, #TODO ?
+                 attn_implementation: str = 'flash_attention_2',
+                 query_dependent: bool = False,
+                 decoder_model_name: str = 'mistralai/Mistral-7B-Instruct-v0.2',
+                 model_max_length: int = 1280,
+                 prompt: str = None,
+                 device_map = 'auto',
+                 **kwargs  # see COCOMConfig for choice of kwargs
+                 ):
+        """
+        Class to use cocom with compression
+        checkpoint_path: path to a COCOM checkpoint
+        context_max_length: maximum length for encoding documents
+        max_new_tokens: maximum number of tokens for generation
+        model_max_length: maximum length used in the final query (should be large enough)
+        """
+        # Lazy import to prevent dependency
+        # Should point to a compatible branch of cocom repo (preferably oscar_pisco release)
+        from cocom.model import COCOM, COCOMConfig
+        
+        Generator.__init__(self,
+                           model_name=model_name,
+                           batch_size=batch_size,
+                           max_new_tokens=max_new_tokens,
+                           max_doc_len=max_doc_len,
+                           max_length=max_length)
+
+        # Loading the cocom model:
+        if model_name is not None:
+            self.model = COCOM.from_pretrained(model_name, device_map=device_map, attn_implementation=attn_implementation)
+            print(f'Loaded cocom from {model_name} has config {self.model.config}')
+        else:
+            cfg = COCOMConfig(
+                decoder_model_name=decoder_model_name,
+                max_new_tokens=128,
+                lora=True,
+                training_form='both_separately',
+                lora_r=16,
+                kbtc_training=False,
+                optimize_mem_tokens=True,
+                different_mem_tokens=True,
+                device_map=device_map,
+                attn_implementation=attn_implementation,
+                **kwargs
+            )
+            print('Creating brand new COCOM model:', cfg)
+            self.model = COCOM(cfg)
+            
+        #self.model.eval() 
+        
+        self.prompt = prompt
+        self.context_max_length = context_max_length
+        
+        self.query_dependent = query_dependent
+        if self.query_dependent:
+            self.context_max_length += 64  # hard-coded at the moment TODO
+            
+        self.max_new_tokens = max_new_tokens
+        self.model_max_length = model_max_length
+        self.tokenizer = self.model.decoder_tokenizer
+        
+    def generate(self, instr_tokenized, return_doc_embeddings: bool = False):
+        """
+        Nothing to do here, just convey to cocom since instr_tokenized went throught the collate_fn
+        """
+        device = next(self.model.parameters()).device
+        instr_tokenized = {k: v.to(device) for k,v in instr_tokenized.items() if isinstance(v, torch.Tensor)}
+        return self.model.generate(instr_tokenized, max_new_tokens=self.max_new_tokens, return_doc_embeddings=return_doc_embeddings)
+
+    def eval(self, dataset):
+        """
+        We re-implement this method since we do not want to use the already existing "TokenizedDataset", we need
+        to do the tokenization deeper in the process.
+        dataset: returned by utils.prepare_dataset_from_ids
+        """
+        assert len(dataset) > 0, 'Empty dataset'
+        self.model.eval() # setting eval mode
+
+        # We get here the generation top k value, used in the encoder/decoder routine to batch encodings.
+        # ideally we would convey it somewhere else, but we use asserts later on to continuously check it's unchanged
+        example_docs = dataset[0]['doc']
+        self.model.generation_top_k = len(example_docs)
+        self.model.eval()
+
+        dataloader = DataLoader(dataset, batch_size=self.batch_size,
+                                    collate_fn=lambda l: self.collate_fn(l, eval=True), num_workers=4)
+
+        responses, instructions, query_ids, queries, labels, ranking_labels = list(), list(), list(), list(), list(), list()
+
+        with torch.no_grad():
+            for data_dict in tqdm(dataloader, desc='Generating'):
+                id_ = data_dict['q_id']
+                instruction = data_dict['instruction']
+                query_ids += id_
+                label = data_dict['label']
+                labels += label
+                queries += data_dict['query']
+                ranking_labels += data_dict['ranking_label']
+                instructions += instruction
+                generated_response = self.generate(data_dict['model_input'], return_doc_embeddings=False)
+                responses += generated_response
+        
+        return query_ids, queries, instructions, responses, labels, ranking_labels
+    
+    def collate_fn(self, examples, eval=False):
+        """
+        Collates a batch of examples.
+
+        Args:
+            examples (list): batch from dataset
+            eval (bool): Whether the function is being called for evaluation.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            dict: Collated batch of data.
+        """
+        batch_size = len(examples)
+
+        ignore_index = -100
+        q_ids = [e['q_id'] for e in examples]
+        query = [e['query'] for e in examples]
+
+        ranking_label = [e['ranking_label'] for e in examples] if 'ranking_label' in examples[0] else [None] * len(examples)
+
+        for ex in examples:
+            assert len(ex['doc']) == self.model.generation_top_k, \
+                f"Not all queries (e.g. {ex['q_id']}) have the same number of docs: not supported here: {len(ex['doc'])} vs {self.model.generation_top_k}"
+
+        #### BULIDING ENCODER INPUTS ####
+        docs = sum([example['doc'] for example in examples], []) # flatten all the docs for encoder input
+        if self.query_dependent:
+            # also add the flattened query to the input for the encoder
+            flattened_query = sum([[q] * self.model.generation_top_k for q in query], [])
+            inp_enc = self.model.prepare_encoder_inputs(texts=docs, q_texts=flattened_query, max_length=self.context_max_length)
+        else:
+            inp_enc = self.model.prepare_encoder_inputs(texts=docs, max_length=self.context_max_length, q_texts=None)
+            
+        enc_input_ids, enc_attention_mask = inp_enc['input_ids'], inp_enc['attention_mask']
+        
+        # input_ids are of shape (top_k * batch_size, enc_token_length)
+        # We can reshape it to (batch_size, top_k, enc_token_length)
+        # for proper batching (important with multi-gpu training)
+        assert enc_input_ids.size(0) == self.model.generation_top_k * batch_size
+        assert len(enc_input_ids.size()) == 2
+        assert enc_attention_mask.size(0) == self.model.generation_top_k * batch_size
+        assert len(enc_attention_mask.size()) == 2
+        enc_input_ids = enc_input_ids.view(batch_size, self.model.generation_top_k, -1)
+        enc_attention_mask = enc_attention_mask.view(batch_size, self.model.generation_top_k, -1)
+
+        #### BUILDING DECODER INPUTS ####
+        mem_tokens_str = ''.join(self.model.decoder_tokenizer.mem_tokens)
+        
+        if self.model.sep:
+            mem_tokens_str += self.model.decoder_tokenizer.sep_token
+
+        # Internally, the model forward will concatenate the memory tokens from all documents for each query
+        # We just need to leave some extra empty tokens when preparing the decoder inputs here:
+        if eval:
+            label = [[e['label']] if isinstance(e['label'], str) else e['label'] for e in examples]
+            instr = [self.compile_prompt(system_prompt=self.prompt.system, 
+                                         user_prompt=self.prompt.user,
+                                         question=q,
+                                         docs=mem_tokens_str * self.model.generation_top_k # placeholder for doc mem embeddings
+                                         )[0] for q in query]
+
+            inp_dec = self.model.decoder_tokenizer(instr, return_tensors='pt', padding="longest", add_special_tokens=False,
+                                        truncation=True,  max_length=self.model_max_length) # TODO what is this length ?
+        else:
+            label = [e['label'] if isinstance(e['label'], str) else random.choice(e['label']) for e in examples]
+                        
+            instr, labels_start = zip(*[self.compile_prompt(
+                                        system_prompt=self.prompt.system, 
+                                        user_prompt=self.prompt.user,
+                                        question=q,
+                                        docs=mem_tokens_str * self.model.generation_top_k, # placeholder for doc mem embeddings
+                                        label=e
+                                        ) for q, e in zip(query, label)])
+            instr, labels_start = list(instr), list(labels_start)
+                
+            inp_dec = self.model.decoder_tokenizer(instr, return_tensors='pt', padding="longest", add_special_tokens=False,
+                                                   truncation=True, max_length=self.model_max_length)
+            
+            # sadly the tokenization with padding added some left padding, so we must update labels accordingly
+            label_ids = inp_dec['input_ids'].clone()
+            for i in range(len(label_ids)):
+                # this counts the amount of left padding added to this particular item in the batch:
+                left_padding_count = (inp_dec['attention_mask'][i] == 0).sum().item()  # This counts the number of padding tokens on the left
+                # we do not count in the loss the padding elements and the question part:
+                label_ids[i, :labels_start[i] + left_padding_count] = ignore_index
+                if labels_start[i] + left_padding_count + 1 > label_ids.size(1):
+                    warnings.warn("Docs + query is too long: label will be ignored. If it happens too often consider\
+                        increasing the `max_seq_length`.")
+                    
+                # We now identify the position of the starting index of the label in the tokenized seq
+                # It is to delimitate where the loss should be computed.
+                no_loss_start_index = self.get_no_loss_start_index(ids=label_ids[i], 
+                                                                   original_labels=label[i],
+                                                                   label_start_index=labels_start[i],
+                                                                   left_padding_count=left_padding_count)
+                
+                # In the label there is only tokens after position padding_count + label_start_index:
+                label_ids[i, :no_loss_start_index] = ignore_index
+                
+        data_dict = {}
+        if not eval:
+            #data_dict['labels'] =  label_ids
+            return {
+            'enc_input_ids': enc_input_ids,
+            'enc_attention_mask': enc_attention_mask,
+            'dec_input_ids': inp_dec['input_ids'],
+            'dec_attention_mask': inp_dec['attention_mask'],
+            'labels': label_ids
+        }
+
+        model_input = {
+            'enc_input_ids': enc_input_ids,
+            'enc_attention_mask': enc_attention_mask,
+            'dec_input_ids': inp_dec['input_ids'],
+            'dec_attention_mask': inp_dec['attention_mask'],
+        }
+        
+        data_dict.update({
+            'model_input': model_input,
+            'q_id': q_ids,
+            'query': query,
+            'instruction': instr,
+            'label': label,
+            'ranking_label': ranking_label,
+        })
+                        
+        return data_dict
+
+    def prediction_step(self, model, model_input, label_ids=None):
+        # used during training
+        output = model.forward(
+            enc_input_ids=model_input['enc_input_ids'],
+            enc_attention_mask=model_input['enc_attention_mask'],
+            dec_input_ids=model_input['dec_input_ids'],
+            dec_attention_mask=model_input['dec_attention_mask'],
+            labels=label_ids
+        )
+            
+        return output['logits'], output['loss']

--- a/models/retrievers/splade.py
+++ b/models/retrievers/splade.py
@@ -47,7 +47,7 @@ class Splade(Retriever):
             }
 
     def collate_fn(self, batch, query_or_doc=None):
-        key = 'generated_query' if query_or_doc=="query" else "content"
+        key = 'generated_query' if query_or_doc == "query" else "content"
         content = [sample[key] for sample in batch]
         return_dict = self.tokenizer(content, padding=True, truncation=True, max_length= self.max_len, return_tensors='pt')
         return return_dict

--- a/modules/processors/mrag_dataset_processor.py
+++ b/modules/processors/mrag_dataset_processor.py
@@ -1,17 +1,16 @@
-from ..dataset_processor import *
+from ..dataset_processor import Processor
 import datasets
 import os
 
 
 class MKQA(Processor):
-
     def __init__(self, lang, *args, **kwargs):
         dataset_name = f'mkqa_{lang}'
         super().__init__(*args, **kwargs, dataset_name=dataset_name)
         self.lang = lang
         
     def process(self):
-        mkqa = datasets.load_dataset('mkqa')
+        mkqa = datasets.load_dataset('mkqa', trust_remote_code=True)
         kilt_nq = datasets.load_dataset("kilt_tasks", "nq")
 
         mkqa_ids = {s['example_id']:i for i, s in enumerate(mkqa[self.split])}
@@ -31,8 +30,8 @@ class MKQA(Processor):
         dataset = dataset.remove_columns(['meta'])
         return dataset
 
-class XORQA(Processor):
 
+class XORQA(Processor):
     def __init__(self, lang, *args, **kwargs):
         dataset_name = f'xor_tydiqa_{lang}'
         self.lang = lang
@@ -51,12 +50,13 @@ class XORQA(Processor):
         # discarding empty answers 
         dataset = dataset.map(lambda example: {'label': extend([el for el in example['answers'] if len(el) > 0], self.lang)})
         dataset = dataset.rename_column("question", "content")
+        dataset = dataset.map(lambda x: {'id': str(x['id'])}) # ids should be strings.
         #dataset = dataset.remove_columns(['meta', 'output'])
         os.system("rm xor_dev_full_v1_1.jsonl")
         return dataset
 
-class TydiQA(Processor):
 
+class TydiQA(Processor):
     def __init__(self, langcode="en", language="english", *args, **kwargs):
         dataset_name = f'tydiqa_{langcode}'
         self.language = language

--- a/print_results.py
+++ b/print_results.py
@@ -119,7 +119,7 @@ def main(args):
     elif args.format =='tiny':
         sel_col =['exp_folder', 'query_dataset', 'Generator', 'Retriever', 'Reranker', "M"] + llmeval_col
     elif args.format =='full':
-        sel_col = ['exp_folder', 'Retriever', 'P_1', 'Reranker', 'Generator',  'gen_time', 'query_dataset', "M", "EM", "F1", "Precision", "Recall","Recall_char3gram", "Rouge-L"]+llmeval_col
+        sel_col = ['exp_folder', 'Retriever', 'P_1', 'Reranker', 'Generator',  'gen_time', 'query_dataset', "M", "EM", "F1", "Precision", "Recall", "Recall_char3gram", "Rouge-L"] + llmeval_col
     else:
         raise ValueError('Invalid output format')
     df=df[sel_col]


### PR DESCRIPTION
If you want to test from NCP (reproduces kilt-NQ inference on OSCAR-llama model based on mistral-7B):

- Put cocom (the oscar_pisco release version on git) in your python path:
`export PYTHONPATH=/home/mlouis/code/cocom:$PYTHONPATH`

- run `python bergen.py   runs_folder='/home/mlouis/code/bergen/runs'   index_folder='/nfs/data/calmar/rag/indexes'         dataset_folder='/nfs/data/calmar/rag/datasets/'    generator='cocom'       +generator.init_args.query_dependent=False   generator.init_args.model_name=/scratch/1/user/mlouis/calmar/query_dependent/llama_32_1b_compr_pt_msmarco_2_epoch_qd/last_model     retriever=splade-v3               reranker=debertav3        dataset=kilt_nq         run_name=test_oscar_pisco     prompt=basic        +generator.init_args.device_map='cuda'`